### PR TITLE
Add system-models for retroboard microservice

### DIFF
--- a/system-models/component.yml
+++ b/system-models/component.yml
@@ -1,0 +1,29 @@
+apiVersion: system-model.autodesk.com/1.0.0
+kind: component
+metadata:
+  computeProvider: aws-lambda
+  deploymentProvider: cloudos-v3
+  description: Serverless Kanban board app with Lambda, DynamoDB, SES, S3, and SQS
+  engineeringManager: user:asarkar157
+  languages:
+    - python
+  namespace: retroboard
+  name: retroboard
+  operationalPurpose: kanban-board
+  productOwner: user:asarkar157
+  runtimes: python
+  sourceRepositories: https://github.com/asarkar157/retroboard
+  serviceTier: 3
+  title: Retroboard Serverless App
+spec:
+  dependsOn:
+    - resource:retroboard/retroboard-dynamodb
+    - resource:retroboard/retroboard-ses
+    - resource:retroboard/retroboard-s3
+    - resource:retroboard/retroboard-sqs
+  lifecycle: steady-state
+  owner: user:asarkar157
+  providesApis:
+    - api:retroboard/retroboard-api
+  partOf: system:retroboard/retroboard
+  type: service

--- a/system-models/resource.yml
+++ b/system-models/resource.yml
@@ -1,0 +1,63 @@
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-dynamodb
+  title: Retroboard - DynamoDB Table
+  description: Stores kanban board data
+  technology: aws-dynamodb
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:asarkar157
+  type: database
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-ses
+  title: Retroboard - SES
+  description: Sends summary emails
+  technology: aws-ses
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:asarkar157
+  type: email-service
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-s3
+  title: Retroboard - S3 Bucket
+  description: Serves static UI assets
+  technology: aws-s3
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:asarkar157
+  type: object-storage
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-sqs
+  title: Retroboard - SQS Queue
+  description: Queues email requests
+  technology: aws-sqs
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:asarkar157
+  type: queue
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard


### PR DESCRIPTION
This PR adds system-models/component.yml and system-models/resource.yml for the retroboard microservice, generated based on architecture and reference templates. 

Generated by Aiden.