### PR TITLE
Add system-model component.yml and resource.yml for retroboard service

### DIFF
--- a/system-models/component.yml
+++ b/system-models/component.yml
@@ -1,0 +1,30 @@
+apiVersion: system-model.autodesk.com/1.0.0
+kind: component
+metadata:
+  computeProvider: aws-lambda
+  deploymentProvider: cloudos-v3
+  description: Retroboard serverless kanban board service
+  engineeringManager: user:unknown
+  languages:
+    - python
+  namespace: retroboard
+  name: retroboard
+  operationalPurpose: kanban-board
+  productOwner: user:unknown
+  runtimes: python
+  sourceRepositories: https://github.com/asarkar157/retroboard
+  serviceTier: 3
+  title: Retroboard Service
+spec:
+  dependsOn:
+    - resource:retroboard/retroboard-dynamodb
+    - resource:retroboard/retroboard-ses
+    - resource:retroboard/retroboard-s3
+    - resource:retroboard/retroboard-sqs
+    - resource:retroboard/retroboard-slack
+  lifecycle: steady-state
+  owner: user:unknown
+  providesApis:
+    - api:retroboard/retroboard-api
+  partOf: system:retroboard/retroboard
+  type: service

--- a/system-models/resource.yml
+++ b/system-models/resource.yml
@@ -1,0 +1,79 @@
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-dynamodb
+  title: Retroboard - DynamoDB Table
+  description: Stores kanban board data
+  technology: aws-dynamodb
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:unknown
+  type: database
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-ses
+  title: Retroboard - SES
+  description: Sends summary emails
+  technology: aws-ses
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:unknown
+  type: email-service
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-s3
+  title: Retroboard - S3 Bucket
+  description: Serves static web UI
+  technology: aws-s3
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:unknown
+  type: object-storage
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-sqs
+  title: Retroboard - SQS Queue
+  description: Queues email requests
+  technology: aws-sqs
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:unknown
+  type: queue
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard
+---
+apiVersion: system-model.autodesk.com/1.0.0
+kind: resource
+metadata:
+  namespace: retroboard
+  name: retroboard-slack
+  title: Retroboard - Slack Webhook
+  description: Sends Slack alerts for new boards
+  technology: slack-webhook
+  sourceRepositories:
+    - https://github.com/asarkar157/retroboard
+spec:
+  owner: user:unknown
+  type: webhook
+  lifecycle: steady-state
+  partOf: system:retroboard/retroboard


### PR DESCRIPTION
This PR adds system-models/component.yml and system-models/resource.yml for the retroboard service, generated based on the repo analysis and reference templates.

Generated by Aiden.