### PR TITLE
chore: add Harness build pipeline for Retroboard frontend

### DIFF
--- a/.pipeline/retroboard-frontend.yaml
+++ b/.pipeline/retroboard-frontend.yaml
@@ -1,0 +1,65 @@
+modules:
+  retroboard_frontend:
+    pipelines:
+      build_frontend:
+        name: "Retroboard Frontend Build"
+        type: build
+        description: "Builds and tests the Retroboard frontend, publishes Akamai artifact"
+        spec:
+          path: "."
+          architecture: amd64
+          os: linux
+          resources:
+            cpu: "1000m"
+            memory: "2Gi"
+          variables:
+            NODE_ENV: "production"
+          commands:
+          - type: build
+            name: Install Dependencies
+            image: node:18-alpine
+            spec:
+              command: |
+                npm ci --prefer-offline
+          - type: build
+            name: Lint Code
+            image: node:18-alpine
+            spec:
+              command: |
+                npm run lint
+          - type: build
+            name: Run Unit Tests
+            image: node:18-alpine
+            spec:
+              command: |
+                npm test -- --reporter=xunit --outputFile=test-results.xml
+              testReportPaths:
+              - "test-results.xml"
+          - type: build
+            name: Build Application
+            image: node:18-alpine
+            spec:
+              command: |
+                npm run build
+                ls -la dist/
+          artifacts:
+            akamai:
+              folder: "dist/"
+          coverage:
+            exclusions:
+            - "**/*.spec.js"
+            - "**/*.test.js"
+            - "**/node_modules/**"
+            reports:
+            - path: "coverage/lcov.info"
+          triggers:
+          - type: commit
+            name: "Build on Frontend Changes"
+            description: "Trigger build on commits to frontend/"
+            enabled: true
+            pushArtifact: true
+            spec:
+              branch: main
+              condition:
+                type: Regex
+                value: ^frontend/


### PR DESCRIPTION
### Summary
This PR introduces a new Harness build pipeline for the Retroboard frontend, located at `/.pipeline/retroboard-frontend.yaml`.

### Pipeline Details
- **Builds and tests the Retroboard frontend** using Node.js 18 Alpine containers.
- **Steps:**
  - Installs dependencies (`npm ci --prefer-offline`)
  - Lints code (`npm run lint`)
  - Runs unit tests with xunit output (`npm test -- --reporter=xunit --outputFile=test-results.xml`)
  - Builds the application (`npm run build`)
- **Artifacts:**
  - Publishes the build output as an Akamai artifact from the `dist/` folder.
- **Coverage:**
  - Excludes test files and node_modules, reports coverage from `coverage/lcov.info`.
- **Trigger:**
  - Runs on commits to the `main` branch that affect the `frontend/` directory.

### Generation Process
- Based on internal CI/CD policy and pipeline examples.
- Used Node.js build as a base, adapted for Akamai artifact and path-filtered trigger.
- Resource limits: 1000m CPU, 2Gi memory.

---

> **Generated by Aiden, your friendly DevOps AI.**
