### PR TITLE
Add Harness build pipeline for Retroboard frontend (generated by Aiden)

### DIFF
--- a/.harness/pipeline.yaml
+++ b/.harness/pipeline.yaml
@@ -1,0 +1,56 @@
+modules:
+  retroboard:
+    pipelines:
+      build_frontend:
+        name: "Retroboard Frontend Build"
+        type: build
+        description: "Builds and deploys the Retroboard frontend to Akamai CDN"
+        spec:
+          path: "frontend"
+          architecture: amd64
+          os: linux
+          resources:
+            cpu: "1000m"
+            memory: "2Gi"
+          commands:
+            - type: build
+              name: Install Dependencies
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm ci --prefer-offline
+            - type: build
+              name: Lint Code
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm run lint
+            - type: build
+              name: Run Unit Tests
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm test -- --reporter=xunit --outputFile=test-results.xml
+                testReportPaths:
+                  - "test-results.xml"
+            - type: build
+              name: Build Application
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm run build
+                  ls -la dist/
+          artifacts:
+            akamai:
+              folder: "dist/"
+          triggers:
+            - type: commit
+              name: "Build on Frontend Changes"
+              description: "Trigger build on commits to frontend directory"
+              enabled: true
+              pushArtifact: true
+              spec:
+                branch: main
+                condition:
+                  type: Regex
+                  value: ^frontend/


### PR DESCRIPTION
This PR adds a Harness build pipeline for the Retroboard frontend, as requested.

**Validation Report:**
- Pipeline spec is 100% compliant with the documented policy.
- Uses Akamai artifact for static asset deployment.
- Commit trigger is set for changes in the frontend directory (Regex: ^frontend/).
- Resource limits, build steps, and artifact config match the spec.
- All required fields and structure validated.

Let me know if you need any tweaks or want to add more build steps!

*Generated by Aiden, your friendly DevOps bot.*