### PR TITLE
Add Harness build pipeline for Retroboard frontend

### DIFF
--- a/.pipeline/build_frontend.yaml
+++ b/.pipeline/build_frontend.yaml
@@ -1,0 +1,56 @@
+modules:
+  retroboard:
+    pipelines:
+      build_frontend:
+        name: "Retroboard Frontend Build"
+        type: build
+        description: "Builds and deploys the Retroboard frontend to Akamai CDN"
+        spec:
+          path: "frontend"
+          architecture: amd64
+          os: linux
+          resources:
+            cpu: "1000m"
+            memory: "2Gi"
+          commands:
+            - type: build
+              name: Install Dependencies
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm ci --prefer-offline
+            - type: build
+              name: Lint Code
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm run lint
+            - type: build
+              name: Run Unit Tests
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm test -- --reporter=xunit --outputFile=test-results.xml
+                testReportPaths:
+                  - "test-results.xml"
+            - type: build
+              name: Build Application
+              image: node:18-alpine
+              spec:
+                command: |
+                  npm run build
+                  ls -la dist/
+          artifacts:
+            akamai:
+              folder: "dist/"
+          triggers:
+            - type: commit
+              name: "Build on Frontend Changes"
+              description: "Trigger build on commits to frontend directory"
+              enabled: true
+              pushArtifact: true
+              spec:
+                branch: main
+                condition:
+                  type: Regex
+                  value: ^frontend/


### PR DESCRIPTION
### Summary
This PR adds a Harness build pipeline YAML for the Retroboard frontend, generated and validated by Aiden.

**Pipeline Generation Steps:**
- Synthesized a compliant pipeline based on internal CI/CD spec and policy.
- Used Akamai artifact for static asset deployment.
- Configured resource limits, build steps, and commit trigger for changes in the frontend directory.
- All required fields and structure validated for spec and policy compliance.

**Pipeline Overview:**
- Installs dependencies, lints code, runs unit tests, and builds the frontend app.
- Artifacts are deployed to Akamai CDN from the dist/ folder.
- Triggered on commits to the frontend directory in the main branch.

**File Location:**
- The pipeline YAML is added at `/.pipeline/build_frontend.yaml`.

---

This PR was generated by Aiden. Please review and merge to enable CI/CD for the Retroboard frontend!
